### PR TITLE
Fixing error when unmarshalling player id

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,12 @@
-build:
+PROJECT_NAME := "mqtt-history"
+
+help: Makefile ## show list of commands
+	@echo "Choose a command run in "$(PROJECT_NAME)":"
+	@echo ""
+	@awk 'BEGIN {FS = ":.*?## "} /[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-40s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
+
+
+build: ## build project
 	@go build -mod vendor -a -installsuffix cgo -o . .
 
 vendor:
@@ -21,20 +29,20 @@ create-cassandra-table:
 	@echo 'Done'
 
 # make setup/mongo MONGODB_HOST=mongodb://localhost:27017 or make MONGODB_HOST=mongodb://localhost:27017 setup/mongo
-setup/mongo:
+setup/mongo: 
 	go run scripts/setup_mongo_messages-index.go
 
-run-tests: run-containers
+run-tests: run-containers ## run tests using the docker containers
 	@make CASSANDRA_CONTAINER=mqtthistory_test_cassandra create-cassandra-table
 	@make coverage
 	@make kill-containers
 
-test: run-tests
+test: run-tests ## run tests using the docker containers (alias to run-tests)
 
 coverage:
 	@go test -coverprofile=coverage.out -covermode=count ./...
 
-run:
+run: ## start the API
 	@go run main.go start
 
 deps:

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ vendor:
 tidy:
 	@go mod tidy
 
-run-containers:
+run-containers: ## run all test containers
 	@cd test_containers && docker-compose up -d && cd ..
 
-kill-containers:
+kill-containers: ## kill all test containers
 	@cd test_containers && docker-compose stop && cd ..
 
 CASSANDRA_CONTAINER := mqtt-history_cassandra_1
@@ -45,7 +45,7 @@ coverage:
 run: ## start the API
 	@go run main.go start
 
-deps:
+deps: ## start the API dependencies as docker containers
 	@docker-compose up -d mongo cassandra
 
 cross: cross-linux cross-darwin

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -12,9 +12,9 @@ cassandra:
 mongo:
   host: "mongodb://localhost:27017"
   allow_anonymous: true
-  database: "mqtt"
+  database: "chat"
   messages:
-    enabled: false
+    enabled: true
     limit: 10
     collection: "messages"
 logger:

--- a/mongoclient/get_messages.go
+++ b/mongoclient/get_messages.go
@@ -1,0 +1,150 @@
+// mqtt-history
+// https://github.com/topfreegames/mqtt-history
+//
+// Licensed under the MIT license:
+// http://www.opensource.org/licenses/mit-license
+// Copyright © 2017 Top Free Games <backend@tfgco.com>
+
+package mongoclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/topfreegames/mqtt-history/logger"
+	"github.com/topfreegames/mqtt-history/models"
+	"go.mongodb.org/mongo-driver/bson"
+
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// MongoMessage represents new payload for the chat message
+// that is stored in MongoDB
+type MongoMessage struct {
+	Id             string      `json:"id" bson:"id"`
+	Timestamp      int64       `json:"timestamp" bson:"timestamp"`
+	Payload        bson.M      `json:"original_payload" bson:"original_payload"`
+	Topic          string      `json:"topic" bson:"topic"`
+	PlayerId       interface{} `json:"player_id" bson:"player_id"`
+	Message        string      `json:"message" bson:"message"`
+	GameId         string      `json:"game_id" bson:"game_id"`
+	Blocked        bool        `json:"blocked" bson:"blocked"`
+	ShouldModerate bool        `json:"should_moderate" bson:"should_moderate"`
+	Metadata       bson.M      `json:"metadata" bson:"metadata"`
+}
+
+// GetMessagesV2 returns messages stored in MongoDB by topic
+// It returns the MessageV2 model that is stored in MongoDB
+func GetMessagesV2(ctx context.Context, topic string, from int64, limit int64, collection string) []*models.MessageV2 {
+	rawResults := make([]MongoMessage, 0)
+
+	callback := func(coll *mongo.Collection) error {
+		query := bson.M{
+			"topic": topic,
+			"timestamp": bson.M{
+				"$lte": from, // less than or equal
+			},
+		}
+
+		sort := bson.D{
+			{"topic", 1},
+			{"timestamp", -1},
+		}
+
+		opts := options.Find()
+		opts.SetSort(sort)
+		opts.SetLimit(limit)
+
+		cursor, err := coll.Find(ctx, query, opts)
+		if err != nil {
+			return err
+		}
+
+		return cursor.All(ctx, &rawResults)
+	}
+
+	// retrieve the collection data
+	err := GetCollection(collection, callback)
+	if err != nil {
+		logger.Logger.Warningf("Error getting messages from MongoDB: %s", err.Error())
+		return []*models.MessageV2{}
+	}
+
+	// convert the raw results to the MessageV2 model
+	searchResults := make([]*models.MessageV2, len(rawResults))
+
+	for i := 0; i < len(rawResults); i++ {
+		searchResults[i], err = convertRawMessageToModelMessage(rawResults[i])
+
+		if err != nil {
+			logger.Logger.Warningf("Error getting messages from MongoDB: %s", err.Error())
+			return []*models.MessageV2{}
+		}
+	}
+
+	return searchResults
+}
+
+// GetMessages returns messages stored in MongoDB by topic
+// since MongoDB uses the MessageV2 format, this method converts
+// the MessageV2 model into the Message one for retrocompatibility
+// Rhe main difference being that the payload field is now referred to as "original_payload" and
+// is a JSON object, not a string, and also the timestamp is int64 seconds since Unix epoch, not an ISODate
+func GetMessages(ctx context.Context, topic string, from int64, limit int64, collection string) []*models.Message {
+	searchResults := GetMessagesV2(ctx, topic, from, limit, collection)
+	messages := make([]*models.Message, 0)
+	for _, result := range searchResults {
+		payload := result.Payload
+		bytes, _ := json.Marshal(payload)
+
+		finalStr := string(bytes)
+		message := &models.Message{
+			Timestamp: time.Unix(result.Timestamp, 0),
+			Payload:   finalStr,
+			Topic:     topic,
+		}
+		messages = append(messages, message)
+	}
+
+	return messages
+}
+
+func convertRawMessageToModelMessage(rawMessage MongoMessage) (*models.MessageV2, error) {
+	playerIdAsString, err := convertPlayerIdToString(rawMessage.PlayerId)
+	if err != nil {
+		return nil, err
+	}
+
+	return &models.MessageV2{
+		Id:             rawMessage.Id,
+		Timestamp:      rawMessage.Timestamp,
+		Payload:        rawMessage.Payload,
+		Topic:          rawMessage.Topic,
+		PlayerId:       playerIdAsString,
+		Message:        rawMessage.Message,
+		GameId:         rawMessage.GameId,
+		Blocked:        rawMessage.Blocked,
+		ShouldModerate: rawMessage.ShouldModerate,
+		Metadata:       rawMessage.Metadata,
+	}, nil
+}
+
+func convertPlayerIdToString(playerID interface{}) (string, error) {
+	_, ok := playerID.(string)
+
+	if ok {
+		// force sprintf to avoid encoding issues
+		return fmt.Sprintf("%s", playerID), nil
+	}
+
+	playerIdAsNumber, ok := playerID.(float64)
+
+	if !ok {
+		return "", fmt.Errorf("error converting player id to float64 or string. player id raw value: %s", playerID)
+	}
+
+	return fmt.Sprintf("%f0", playerIdAsNumber), nil
+}

--- a/mongoclient/mongoclient.go
+++ b/mongoclient/mongoclient.go
@@ -9,12 +9,9 @@ package mongoclient
 
 import (
 	"context"
-	"encoding/json"
 	"sync"
 	"time"
 
-	"github.com/topfreegames/mqtt-history/models"
-	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 
 	"github.com/spf13/viper"
@@ -66,66 +63,4 @@ func GetCollection(collection string, s func(collection *mongo.Collection) error
 
 	c := mongoDB.Database(database, dbOpts).Collection(collection)
 	return s(c)
-}
-
-// GetMessagesV2 returns messages stored in MongoDB by topic
-// It returns the MessageV2 model that is stored in MongoDB
-func GetMessagesV2(ctx context.Context, topic string, from int64, limit int64, collection string) []*models.MessageV2 {
-	searchResults := make([]*models.MessageV2, 0)
-
-	callback := func(coll *mongo.Collection) error {
-		query := bson.M{
-			"topic": topic,
-			"timestamp": bson.M{
-				"$lte": from, // less than or equal
-			},
-		}
-
-		sort := bson.D{
-			{"topic", 1},
-			{"timestamp", -1},
-		}
-
-		opts := options.Find()
-		opts.SetSort(sort)
-		opts.SetLimit(limit)
-
-		cursor, err := coll.Find(ctx, query, opts)
-		if err != nil {
-			return err
-		}
-
-		return cursor.All(ctx, &searchResults)
-	}
-
-	err := GetCollection(collection, callback)
-	if err != nil {
-		return []*models.MessageV2{}
-	}
-
-	return searchResults
-}
-
-// GetMessages returns messages stored in MongoDB by topic
-// since MongoDB uses the MessageV2 format, this method converts
-// the MessageV2 model into the Message one for retrocompatibility
-// Rhe main difference being that the payload field is now referred to as "original_payload" and
-// is a JSON object, not a string, and also the timestamp is int64 seconds since Unix epoch, not an ISODate
-func GetMessages(ctx context.Context, topic string, from int64, limit int64, collection string) []*models.Message {
-	searchResults := GetMessagesV2(ctx, topic, from, limit, collection)
-	messages := make([]*models.Message, 0)
-	for _, result := range searchResults {
-		payload := result.Payload
-		bytes, _ := json.Marshal(payload)
-
-		finalStr := string(bytes)
-		message := &models.Message{
-			Timestamp: time.Unix(result.Timestamp, 0),
-			Payload:   finalStr,
-			Topic:     topic,
-		}
-		messages = append(messages, message)
-	}
-
-	return messages
 }


### PR DESCRIPTION
# Motivation

Given we added a feature to use MongoDB to storage instead of Cassandra, we need to deal with changes of the typing that could occur on Mongo. On this MR we are changing the way how we Unmarshall messages to consider PlayerID as a number too.

# Technical Debt

In the next releases, we need to think about how we can improve unmarshalling procedures for other message fields.

# How to test it

## Pre-requisites

1. Start the database and populate MongoDB with `make deps setup/mongo`;
2. Connect into mongoDB and run the following command:
```sh
> use chat

> db.messages.insertMany([
  {
    _id: ObjectId("61f18d6e901b304d707fd803"),
    id: 'urn:uuid:fe67bc4a-6517-4c96-a89d-09b7fe6e1e8e',
    player_id: 1,
    game_id: 'mygame',
    topic: 'chat/mygame/room/general',
    message: 'Hello World',
    timestamp: 1643220334,
    blocked: false,
    metadata: {
      blocked: false,
      Type: 1,
      Time: NumberLong("637788171338607270"),
      Sender: { PlayerId: 1, Name: 'Bob' },
      Message: 'Hello World',
      Mentions: [],
      Id: 'urn:uuid:fe67bc4a-6517-4c96-a89d-09b7fe6e1e8e',
      GameId: 'mygame'
    },
    should_moderate: true,
    original_payload: {
      blocked: false,
      Type: 1,
      Time: NumberLong("637788171338607270"),
      Sender: { PlayerId: 1, Name: 'Bob' },
      Message: 'Hello World',
      Mentions: [],
      Id: 'urn:uuid:fe67bc4a-6517-4c96-a89d-09b7fe6e1e8e',
      GameId: 'mygame'
    }
  },
  {
    _id: ObjectId("61f0f98027b114a532751e05"),
    id: 'urn:uuid:cf7711d6-95df-4be7-8b9a-6ecfb812c408',
    player_id: 'alice',
    game_id: 'myanothergame',
    topic: 'chat/myanothergame/room/general',
    message: 'Hi',
    timestamp: 1643182464,
    blocked: false,
    metadata: {
      blocked: false,
      Type: 1,
      Time: NumberLong("637787792628932950"),
      Sender: { PlayerId: 'alice', Name: 'Alice' },
      Message: 'Hi',
      Mentions: [],
      Id: 'urn:uuid:cf7711d6-95df-4be7-8b9a-6ecfb812c408',
      GameId: 'myanothergame'
    },
    should_moderate: true,
    original_payload: {
      blocked: false,
      Type: 1,
      Time: NumberLong("637787792628932950"),
      Sender: { PlayerId: 'alice', Name: 'Alice' },
      Message: 'Hi',
      Mentions: [],
      Id: 'urn:uuid:cf7711d6-95df-4be7-8b9a-6ecfb812c408',
      GameId: 'myanothergame'
    }
  }
])
```

3. Start the API with `make run`.

## Test cases

### Retrieving messages from games that have `PlayerId` as a number

- **Given** I am an API consumer
- **When** I try to query my game messages
```sh
curl --location --request GET 'http://localhost:8888/history/chat/mygame/room/general?userid=mygame:metagame-mygame&limit=1000'
```
- **Then** I should return JSON array with my messages
```sh
# you should see an array with one message from Bob
```
- **And** no warning log should be triggered API output

### Retrieving messages from games that have `PlayerId` as a string

- **Given** I am an API consumer
- **When** I try to query my game messages
```sh
curl --location --request GET 'http://localhost:8888/history/chat/myanothergame/room/general?userid=myanothergame:metagame-myanothergame&limit=1000'
```
- **Then** I should return JSON array with my messages
```sh
# you should see an array with one message from Alice
```
- **And** no warning log should be triggered API output