### PR TITLE
Fix conversion bug

### DIFF
--- a/mongoclient/get_messages.go
+++ b/mongoclient/get_messages.go
@@ -133,18 +133,33 @@ func convertRawMessageToModelMessage(rawMessage MongoMessage) (*models.MessageV2
 }
 
 func convertPlayerIdToString(playerID interface{}) (string, error) {
-	_, ok := playerID.(string)
+	// TODO: refactor this code using switch to improve readability
 
+	_, ok := playerID.(string)
 	if ok {
 		// force sprintf to avoid encoding issues
 		return fmt.Sprintf("%s", playerID), nil
 	}
 
-	playerIdAsNumber, ok := playerID.(float64)
-
-	if !ok {
-		return "", fmt.Errorf("error converting player id to float64 or string. player id raw value: %s", playerID)
+	playerIdAsFloat32, ok := playerID.(float32)
+	if ok {
+		return fmt.Sprintf("%f0", playerIdAsFloat32), nil
 	}
 
-	return fmt.Sprintf("%f0", playerIdAsNumber), nil
+	playerIdAsFloat64, ok := playerID.(float64)
+	if ok {
+		return fmt.Sprintf("%f0", playerIdAsFloat64), nil
+	}
+
+	playerIdAsInt32, ok := playerID.(int32)
+	if ok {
+		return fmt.Sprintf("%d", playerIdAsInt32), nil
+	}
+
+	playerIdAsInt64, ok := playerID.(int64)
+	if ok {
+		return fmt.Sprintf("%d", playerIdAsInt64), nil
+	}
+
+	return "", fmt.Errorf("error converting player id to float64 or string. player id raw value: %s", playerID)
 }


### PR DESCRIPTION
# Motivation

Given we added a feature to use MongoDB to storage instead of Cassandra, we need to deal with changes of the typing that could occur on Mongo. On this MR we are changing the way how we Unmarshall messages to consider PlayerID as a number too. This PR extends the number checking on #16 .

# Technical Debt

In the next releases, we need to think about how we can improve unmarshalling procedures for other message fields.

# How to test it

## Pre-requisites

1. Start the database and populate MongoDB with `make deps setup/mongo`;
2. Connect into mongoDB and run the following command:
```sh
> use chat

> db.messages.insertMany([
  {
    _id: ObjectId("61f18d6e901b304d707fd803"),
    id: 'urn:uuid:fe67bc4a-6517-4c96-a89d-09b7fe6e1e8e',
    player_id: 1,
    game_id: 'mygame',
    topic: 'chat/mygame/room/general',
    message: 'Hello World',
    timestamp: 1643220334,
    blocked: false,
    metadata: {
      blocked: false,
      Type: 1,
      Time: NumberLong("637788171338607270"),
      Sender: { PlayerId: 1, Name: 'Bob' },
      Message: 'Hello World',
      Mentions: [],
      Id: 'urn:uuid:fe67bc4a-6517-4c96-a89d-09b7fe6e1e8e',
      GameId: 'mygame'
    },
    should_moderate: true,
    original_payload: {
      blocked: false,
      Type: 1,
      Time: NumberLong("637788171338607270"),
      Sender: { PlayerId: 1, Name: 'Bob' },
      Message: 'Hello World',
      Mentions: [],
      Id: 'urn:uuid:fe67bc4a-6517-4c96-a89d-09b7fe6e1e8e',
      GameId: 'mygame'
    }
  },
  {
    _id: ObjectId("61f0f98027b114a532751e05"),
    id: 'urn:uuid:cf7711d6-95df-4be7-8b9a-6ecfb812c408',
    player_id: 'alice',
    game_id: 'myanothergame',
    topic: 'chat/myanothergame/room/general',
    message: 'Hi',
    timestamp: 1643182464,
    blocked: false,
    metadata: {
      blocked: false,
      Type: 1,
      Time: NumberLong("637787792628932950"),
      Sender: { PlayerId: 'alice', Name: 'Alice' },
      Message: 'Hi',
      Mentions: [],
      Id: 'urn:uuid:cf7711d6-95df-4be7-8b9a-6ecfb812c408',
      GameId: 'myanothergame'
    },
    should_moderate: true,
    original_payload: {
      blocked: false,
      Type: 1,
      Time: NumberLong("637787792628932950"),
      Sender: { PlayerId: 'alice', Name: 'Alice' },
      Message: 'Hi',
      Mentions: [],
      Id: 'urn:uuid:cf7711d6-95df-4be7-8b9a-6ecfb812c408',
      GameId: 'myanothergame'
    }
  }
])
```

3. Start the API with `make run`.

## Test cases

### Retrieving messages from games that have `PlayerId` as a number

- **Given** I am an API consumer
- **When** I try to query my game messages
```sh
curl --location --request GET 'http://localhost:8888/history/chat/mygame/room/general?userid=mygame:metagame-mygame&limit=1000'
```
- **Then** I should return JSON array with my messages
```sh
# you should see an array with one message from Bob
```
- **And** no warning log should be triggered API output

### Retrieving messages from games that have `PlayerId` as a string

- **Given** I am an API consumer
- **When** I try to query my game messages
```sh
curl --location --request GET 'http://localhost:8888/history/chat/myanothergame/room/general?userid=myanothergame:metagame-myanothergame&limit=1000'
```
- **Then** I should return JSON array with my messages
```sh
# you should see an array with one message from Alice
```
- **And** no warning log should be triggered API output