### PR TITLE
Change mqtt history to avoid sending blocked

### DIFF
--- a/app/histories_v2.go
+++ b/app/histories_v2.go
@@ -37,7 +37,16 @@ func HistoriesV2Handler(app *App) func(c echo.Context) error {
 
 		for _, topic := range authorizedTopics {
 			topicMessages := mongoclient.GetMessagesV2(c, topic, from, limit, collection)
-			messages = append(messages, topicMessages...)
+			// se eu tirar as mensagens, vou precisar tirar tmb os topicos relacionados a essas mensagens? pq estao correlacionados
+			//range topicmessages
+			for _, message := range topicMessages {
+				if !message.Blocked {
+					messages = append(messages, topicMessages...)
+					//primeiro item precisa ser o slice que eu quero
+					// criei um filtro para as mensagens bloqueadas, como construir um novo array para guardar essas msgns filtradas?
+					print(messages)
+				}
+			}
 		}
 		return c.JSON(http.StatusOK, messages)
 	}

--- a/app/histories_v2.go
+++ b/app/histories_v2.go
@@ -37,11 +37,7 @@ func HistoriesV2Handler(app *App) func(c echo.Context) error {
 
 		for _, topic := range authorizedTopics {
 			topicMessages := mongoclient.GetMessagesV2(c, topic, from, limit, collection)
-			for _, message := range topicMessages {
-				if !message.Blocked {
-					messages = append(messages, topicMessages...)
-				}
-			}
+			messages = append(messages, topicMessages...)
 		}
 		return c.JSON(http.StatusOK, messages)
 	}

--- a/app/histories_v2.go
+++ b/app/histories_v2.go
@@ -37,14 +37,9 @@ func HistoriesV2Handler(app *App) func(c echo.Context) error {
 
 		for _, topic := range authorizedTopics {
 			topicMessages := mongoclient.GetMessagesV2(c, topic, from, limit, collection)
-			// se eu tirar as mensagens, vou precisar tirar tmb os topicos relacionados a essas mensagens? pq estao correlacionados
-			//range topicmessages
 			for _, message := range topicMessages {
 				if !message.Blocked {
 					messages = append(messages, topicMessages...)
-					//primeiro item precisa ser o slice que eu quero
-					// criei um filtro para as mensagens bloqueadas, como construir um novo array para guardar essas msgns filtradas?
-					print(messages)
 				}
 			}
 		}

--- a/app/history_test.go
+++ b/app/history_test.go
@@ -151,6 +151,8 @@ func TestHistoryHandler(t *testing.T) {
 			})
 
 			g.It("It should return 200 and the unblocked messages if the user is authorized into the topic ", func() {
+				a.Defaults.MongoEnabled = true
+
 				testID := strings.Replace(uuid.NewV4().String(), "-", "", -1)
 				topic := fmt.Sprintf("chat/test_%s", testID)
 				userID := "test:test"
@@ -164,18 +166,16 @@ func TestHistoryHandler(t *testing.T) {
 				err = InsertMongoMessagesWithParameters(ctx, []string{topic}, true)
 				Expect(err).To(BeNil())
 
-				path := fmt.Sprintf("/v2/history/%s?userid=%s&limit=1000", topic, userID)
+				path := fmt.Sprintf("/history/%s?userid=%s&limit=1000", topic, userID)
 				status, body := Get(a, path, t)
 				g.Assert(status).Equal(http.StatusOK)
 
-				var messages []models.MessageV2
+				var messages []models.Message
 
 				err = json.Unmarshal([]byte(body), &messages)
 				Expect(err).To(BeNil())
 
 				g.Assert(len(messages)).Equal(1)
-				g.Assert(messages[0].Blocked).Equal(false)
-
 			})
 		})
 	})

--- a/app/history_v2.go
+++ b/app/history_v2.go
@@ -31,10 +31,17 @@ func HistoryV2Handler(app *App) func(c echo.Context) error {
 		if !authenticated {
 			return c.String(echo.ErrUnauthorized.Code, echo.ErrUnauthorized.Message)
 		}
-		messages := make([]*models.MessageV2, 0)
-		collection := app.Defaults.MongoMessagesCollection
-		messages = mongoclient.GetMessagesV2(c, topic, from, limit, collection)
 
+		messages := make([]*models.MessageV2, 0)
+		allMessages := make([]*models.MessageV2, 0)
+		collection := app.Defaults.MongoMessagesCollection
+		allMessages = mongoclient.GetMessagesV2(c, topic, from, limit, collection)
+
+		for _, message := range allMessages {
+			if !message.Blocked {
+				messages = append(messages, allMessages...)
+			}
+		}
 		return c.JSON(http.StatusOK, messages)
 	}
 }

--- a/app/history_v2.go
+++ b/app/history_v2.go
@@ -33,15 +33,9 @@ func HistoryV2Handler(app *App) func(c echo.Context) error {
 		}
 
 		messages := make([]*models.MessageV2, 0)
-		allMessages := make([]*models.MessageV2, 0)
 		collection := app.Defaults.MongoMessagesCollection
-		allMessages = mongoclient.GetMessagesV2(c, topic, from, limit, collection)
+		messages = mongoclient.GetMessagesV2(c, topic, from, limit, collection)
 
-		for _, message := range allMessages {
-			if !message.Blocked {
-				messages = append(messages, allMessages...)
-			}
-		}
 		return c.JSON(http.StatusOK, messages)
 	}
 }

--- a/app/history_v2_test.go
+++ b/app/history_v2_test.go
@@ -79,23 +79,32 @@ func TestHistoryV2Handler(t *testing.T) {
 				Expect(err).To(BeNil())
 			})
 
-			g.It("It should return 200 and [] if the user is authorized into the topic but there are only blocked messages", func() {
+			g.It("It should return 200 and the unblocked messages if the user is authorized into the topic ", func() {
 				testID := strings.Replace(uuid.NewV4().String(), "-", "", -1)
 				topic := fmt.Sprintf("chat/test_%s", testID)
+				userID := "test:test"
 
 				err := AuthorizeTestUserInTopics(ctx, []string{topic})
 				Expect(err).To(BeNil())
 
-				path := fmt.Sprintf("/history/%s?userid=test:test", topic)
+				err = InsertMongoMessagesWithParameters(ctx, []string{topic}, false)
+				Expect(err).To(BeNil())
+
+				err = InsertMongoMessagesWithParameters(ctx, []string{topic}, true)
+				Expect(err).To(BeNil())
+
+				path := fmt.Sprintf("/v2/history/%s?userid=%s&limit=1000", topic, userID)
 				status, body := Get(a, path, t)
 				g.Assert(status).Equal(http.StatusOK)
 
 				var messages []models.MessageV2
-				g.Assert(len(messages)).Equal(0)
-				g.Assert(append(messages, models.MessageV2{Blocked: true}))
 
 				err = json.Unmarshal([]byte(body), &messages)
 				Expect(err).To(BeNil())
+
+				g.Assert(len(messages)).Equal(1)
+				g.Assert(messages[0].Blocked).Equal(false)
+
 			})
 		})
 	})

--- a/app/history_v2_test.go
+++ b/app/history_v2_test.go
@@ -78,6 +78,25 @@ func TestHistoryV2Handler(t *testing.T) {
 				g.Assert(len(messages)).Equal(0)
 				Expect(err).To(BeNil())
 			})
+
+			g.It("It should return 200 and [] if the user is authorized into the topic but there are only blocked messages", func() {
+				testID := strings.Replace(uuid.NewV4().String(), "-", "", -1)
+				topic := fmt.Sprintf("chat/test_%s", testID)
+
+				err := AuthorizeTestUserInTopics(ctx, []string{topic})
+				Expect(err).To(BeNil())
+
+				path := fmt.Sprintf("/history/%s?userid=test:test", topic)
+				status, body := Get(a, path, t)
+				g.Assert(status).Equal(http.StatusOK)
+
+				var messages []models.MessageV2
+				g.Assert(len(messages)).Equal(0)
+				g.Assert(append(messages, models.MessageV2{Blocked: true}))
+
+				err = json.Unmarshal([]byte(body), &messages)
+				Expect(err).To(BeNil())
+			})
 		})
 	})
 }

--- a/mongoclient/get_messages.go
+++ b/mongoclient/get_messages.go
@@ -47,6 +47,7 @@ func GetMessagesV2(ctx context.Context, topic string, from int64, limit int64, c
 			"timestamp": bson.M{
 				"$lte": from, // less than or equal
 			},
+			"blocked": false,
 		}
 
 		sort := bson.D{

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -86,13 +86,18 @@ func AuthorizeTestUserInTopics(ctx context.Context, topics []string) error {
 }
 
 func InsertMongoMessages(ctx context.Context, topics []string) error {
+	return InsertMongoMessagesWithParameters(ctx, topics, false)
+}
+
+//primeira maneira de fazer, porem altera os outros lugfares que precisariam da func
+func InsertMongoMessagesWithParameters(ctx context.Context, topics []string, blocked bool) error {
 	var messages []interface{}
 	for i, topic := range topics {
 		message := models.MessageV2{
 			Id:             strconv.FormatInt(int64(i), 10),
 			GameId:         "game test",
 			PlayerId:       "test",
-			Blocked:        false,
+			Blocked:        blocked,
 			ShouldModerate: true,
 			Timestamp:      time.Now().AddDate(0, 0, -i).Unix(),
 			Payload: bson.M{


### PR DESCRIPTION
# Motivation

Given the needed of saving banned messages in our database, MQTT History was changed to avoid sending these banned/blocked messages to the users. On this MR we are adding a validation in the responsible component for the treatment of the messages for them to not return when get the boolean flag ''blocked:true''.

# How to test it

## Pre-requisites

1. Start the database and populate MongoDB with `make deps setup/mongo`;
2. Connect into mongoDB and run the following command:
```sh
> use chat

> db.messages.insertMany([
  {
    _id: ObjectId("61f18d6e901b304d707fd803"),
    id: 'urn:uuid:fe67bc4a-6517-4c96-a89d-09b7fe6e1e8e',
    player_id: 1,
    game_id: 'mygame',
    topic: 'chat/mygame/room/general',
    message: 'Hello World',
    timestamp: 1643220334,
    blocked: false,
    metadata: {
      blocked: false,
      Type: 1,
      Time: NumberLong("637788171338607270"),
      Sender: { PlayerId: 1, Name: 'Bob' },
      Message: 'Hello World',
      Mentions: [],
      Id: 'urn:uuid:fe67bc4a-6517-4c96-a89d-09b7fe6e1e8e',
      GameId: 'mygame'
    },
    should_moderate: true,
    original_payload: {
      blocked: false,
      Type: 1,
      Time: NumberLong("637788171338607270"),
      Sender: { PlayerId: 1, Name: 'Bob' },
      Message: 'Hello World',
      Mentions: [],
      Id: 'urn:uuid:fe67bc4a-6517-4c96-a89d-09b7fe6e1e8e',
      GameId: 'mygame'
    }
  },
  {
    _id: ObjectId("61f0f98027b114a532751e05"),
    id: 'urn:uuid:cf7711d6-95df-4be7-8b9a-6ecfb812c408',
    player_id: 'alice',
    game_id: 'myanothergame',
    topic: 'chat/myanothergame/room/general',
    message: 'Hi',
    timestamp: 1643182464,
    blocked: true,
    metadata: {
      blocked: true,
      Type: 1,
      Time: NumberLong("637787792628932950"),
      Sender: { PlayerId: 'alice', Name: 'Alice' },
      Message: 'Hi',
      Mentions: [],
      Id: 'urn:uuid:cf7711d6-95df-4be7-8b9a-6ecfb812c408',
      GameId: 'myanothergame'
    },
    should_moderate: true,
    original_payload: {
      blocked: true,
      Type: 1,
      Time: NumberLong("637787792628932950"),
      Sender: { PlayerId: 'alice', Name: 'Alice' },
      Message: 'Hi',
      Mentions: [],
      Id: 'urn:uuid:cf7711d6-95df-4be7-8b9a-6ecfb812c408',
      GameId: 'myanothergame'
    }
  }
])
```

3. Start the API with `make run`.

## Test cases

### Retrieving messages from games that have `blocked:false` 

- **Given** I am an API consumer
- **When** I try to query my game messages
```sh
curl --location --request GET 'http://localhost:8888/history/chat/mygame/room/general?userid=mygame:metagame-mygame&limit=1000'
```
- **Then** I should return JSON array with my messages
```sh
# you should see an array with one message from Bob
```

### Retrieving messages from games that have `blocked:true`

- **Given** I am an API consumer
- **When** I try to query my game messages
```sh
curl --location --request GET 'http://localhost:8888/history/chat/myanothergame/room/general?userid=myanothergame:metagame-myanothergame&limit=1000'
```
- **Then** I should return JSON array with no messages
```sh
# you should see an empty array because Alice's messages are blocked
```
