### PR TITLE
Get chatlogs by room

### DIFF
--- a/app/history_v2_player_support_test.go
+++ b/app/history_v2_player_support_test.go
@@ -72,6 +72,28 @@ func TestHistoryV2PSHandler(t *testing.T) {
 
 			})
 
+			g.It("It should return 200 and unblocked messages from the given topic and date.", func() {
+				testID := strings.Replace(uuid.NewV4().String(), "-", "", -1)
+				topic := fmt.Sprintf("chat/test_%s", testID)
+				finalDate := strings.Split(time.Now().AddDate(0, 0, 1).UTC().String(), " ")[0]
+
+				err := InsertMongoMessagesWithParameters(ctx, []string{topic}, false)
+				Expect(err).To(BeNil())
+
+				path := fmt.Sprintf("/ps/v2/history?topic=%s&initialDate=2022-01-01&finalDate=%s", topic, finalDate)
+				status, body := Get(a, path, t)
+				g.Assert(status).Equal(http.StatusOK)
+
+				var messages []models.MessageV2
+
+				err = json.Unmarshal([]byte(body), &messages)
+				Expect(err).To(BeNil())
+
+				g.Assert(len(messages)).Equal(1)
+				g.Assert(messages[0].Blocked).Equal(false)
+
+			})
+
 			g.It("It should return 422 and an error message if the date parameter is being missed", func() {
 				testID := strings.Replace(uuid.NewV4().String(), "-", "", -1)
 				topic := fmt.Sprintf("chat/test_%s", testID)

--- a/mongoclient/get_messages.go
+++ b/mongoclient/get_messages.go
@@ -204,6 +204,21 @@ func GetMessagesPlayerSupportV2WithParameter(ctx context.Context, topic string, 
 			}
 		}
 
+		if playerId == "" {
+			query = bson.M{
+				"timestamp": bson.M{
+					"$gte": from,
+					"$lte": to,
+				},
+				"topic":   topic,
+				"blocked": isBlocked,
+			}
+			sort = bson.D{
+				{"topic", 1},
+				{"timestamp", -1},
+			}
+		}
+
 		opts := options.Find()
 		opts.SetSort(sort)
 		opts.SetLimit(limit)


### PR DESCRIPTION
# Motivation

Given the needed of filtering messages from MQTT History by topic and also filtering them by start date, end date: on this MR we are we creating a new query with three most important endpoints to introduce a better experience for users that want to analyze the data of the messages.

# How to test it

## Pre-requisites

1. Start the database and populate MongoDB with `make deps setup/mongo`;
2. Connect into mongoDB and run the following command:
```sh
> use chat

> db.messages.insertMany([
  {
    _id: ObjectId("61f18d6e901b304d707fd803"),
    id: 'urn:uuid:fe67bc4a-6517-4c96-a89d-09b7fe6e1e8e',
    player_id: '3727a9b4-dfa9-457a-9257-d2a7090d6955',
    game_id: 'mygame',
    topic: 'chat/mygame/room/general',
    message: 'Hello World',
    timestamp: 1643220334,
    blocked: false,
    metadata: {
      blocked: false,
      Type: 1,
      Time: NumberLong("637788171338607270"),
      Sender: { PlayerId: '3727a9b4-dfa9-457a-9257-d2a7090d6955', Name: 'Bob' },
      Message: 'Hello World',
      Mentions: [],
      Id: 'urn:uuid:fe67bc4a-6517-4c96-a89d-09b7fe6e1e8e',
      GameId: 'mygame'
    },
    should_moderate: true,
    original_payload: {
      blocked: false,
      Type: 1,
      Time: NumberLong("637788171338607270"),
      Sender: { PlayerId: '3727a9b4-dfa9-457a-9257-d2a7090d6955', Name: 'Bob' },
      Message: 'Hello World',
      Mentions: [],
      Id: 'urn:uuid:fe67bc4a-6517-4c96-a89d-09b7fe6e1e8e',
      GameId: 'mygame'
    }
  },
    {
      _id: ObjectId("61f18d6e901b304d707fd805"),
      id: 'urn:uuid:fe67bc4a-6517-4c96-a89d-09b7fe6e1e8f',
      player_id: '3727a9b4-dfa9-457a-9257-d2a7090d6955',
      game_id: 'mygame',
      topic: 'chat/blabla/room/general',
      message: 'Hello World',
      timestamp: 1643220334,
      blocked: false,
      metadata: {
        blocked: false,
        Type: 1,
        Time: NumberLong("637788171338607270"),
        Sender: { PlayerId: '3727a9b4-dfa9-457a-9257-d2a7090d6955', Name: 'Bob' },
        Message: 'Hello World Again',
        Mentions: [],
        Id: 'urn:uuid:fe67bc4a-6517-4c96-a89d-09b7fe6e1e8e',
        GameId: 'mygame'
      },
      should_moderate: true,
      original_payload: {
        blocked: false,
        Type: 1,
        Time: NumberLong("637788171338607270"),
        Sender: { PlayerId: '3727a9b4-dfa9-457a-9257-d2a7090d6955', Name: 'Bob' },
        Message: 'Hello World',
        Mentions: [],
        Id: 'urn:uuid:fe67bc4a-6517-4c96-a89d-09b7fe6e1e8e',
        GameId: 'mygame'
      }
    }
])
```

3. Start the API with `make run`.

## Test cases

### Retrieving messages from a specific topic without specifying a player.

- **Given** I am an API consumer
- **When** I try to query my game messages
```sh
curl --location --request GET 'http://localhost:8888/ps/v2/history?topic=chat/mygame/room/general&initialDate=2022-01-01&finalDate=2022-05-05'
```
- **Then** I should return a JSON array with my messages 
```sh
# you should see an array with one message from Bob on topic `chat/mygame/room/general`
```

--