### PR TITLE
Feat/improve mqtt response time miliseconds

### DIFF
--- a/app/histories_v2.go
+++ b/app/histories_v2.go
@@ -41,10 +41,8 @@ func HistoriesV2Handler(app *App) func(c echo.Context) error {
 		}
 
 		gameId := messages[0].GameId
-		metricTagMap := c.Get("metricTagsMap").(map[string]interface{})
-		if metricTagMap != nil {
-			metricTagMap["gameID"] = gameId
-			logger.Logger.Debugf("provided gameID: %s", metricTagMap["gameID"])
+		if metricTagsMap, ok := c.Get("metricTagsMap").(map[string]interface{}); ok {
+				metricTagsMap["gameID"] = gameId
 		}
 
 		return c.JSON(http.StatusOK, messages)

--- a/app/histories_v2.go
+++ b/app/histories_v2.go
@@ -39,6 +39,14 @@ func HistoriesV2Handler(app *App) func(c echo.Context) error {
 			topicMessages := mongoclient.GetMessagesV2(c, topic, from, limit, collection)
 			messages = append(messages, topicMessages...)
 		}
+
+		gameId := messages[0].GameId
+		metricTagMap := c.Get("metricTagsMap").(map[string]interface{})
+		if metricTagMap != nil {
+			metricTagMap["gameID"] = gameId
+			logger.Logger.Debugf("provided gameID: %s", metricTagMap["gameID"])
+		}
+
 		return c.JSON(http.StatusOK, messages)
 	}
 }

--- a/app/histories_v2.go
+++ b/app/histories_v2.go
@@ -40,9 +40,11 @@ func HistoriesV2Handler(app *App) func(c echo.Context) error {
 			messages = append(messages, topicMessages...)
 		}
 
-		gameId := messages[0].GameId
-		if metricTagsMap, ok := c.Get("metricTagsMap").(map[string]interface{}); ok {
+		if len(messages) > 0 {
+			gameId := messages[0].GameId
+			if metricTagsMap, ok := c.Get("metricTagsMap").(map[string]interface{}); ok {
 				metricTagsMap["gameID"] = gameId
+			}
 		}
 
 		return c.JSON(http.StatusOK, messages)

--- a/app/history_v2.go
+++ b/app/history_v2.go
@@ -35,11 +35,11 @@ func HistoryV2Handler(app *App) func(c echo.Context) error {
 		collection := app.Defaults.MongoMessagesCollection
 		messages = mongoclient.GetMessagesV2WithParameter(c, topic, from, limit, collection, isBlocked)
 
-		gameId := messages[0].GameId
-		metricTagMap := c.Get("metricTagsMap").(map[string]interface{})
-		if metricTagMap != nil {
-			metricTagMap["gameID"] = gameId
-			logger.Logger.Debugf("provided gameID: %s", metricTagMap["gameID"])
+		if len(messages) > 0 {
+			gameId := messages[0].GameId
+			if metricTagsMap, ok := c.Get("metricTagsMap").(map[string]interface{}); ok {
+				metricTagsMap["gameID"] = gameId
+			}
 		}
 
 		return c.JSON(http.StatusOK, messages)

--- a/app/history_v2.go
+++ b/app/history_v2.go
@@ -35,6 +35,13 @@ func HistoryV2Handler(app *App) func(c echo.Context) error {
 		collection := app.Defaults.MongoMessagesCollection
 		messages = mongoclient.GetMessagesV2WithParameter(c, topic, from, limit, collection, isBlocked)
 
+		gameId := messages[0].GameId
+		metricTagMap := c.Get("metricTagsMap").(map[string]interface{})
+		if metricTagMap != nil {
+			metricTagMap["gameID"] = gameId
+			logger.Logger.Debugf("provided gameID: %s", metricTagMap["gameID"])
+		}
+
 		return c.JSON(http.StatusOK, messages)
 	}
 }

--- a/app/history_v2_player_support.go
+++ b/app/history_v2_player_support.go
@@ -38,6 +38,13 @@ func HistoriesV2PSHandler(app *App) func(c echo.Context) error {
 		collection := app.Defaults.MongoMessagesCollection
 		messages = mongoclient.GetMessagesPlayerSupportV2WithParameter(c, topic, from, to, limit, collection, isBlocked, playerId)
 
+		gameId := messages[0].GameId
+		metricTagMap := c.Get("metricTagsMap").(map[string]interface{})
+		if metricTagMap != nil {
+			metricTagMap["gameID"] = gameId
+			logger.Logger.Debugf("provided gameID: %s", metricTagMap["gameID"])
+		}
+
 		return c.JSON(http.StatusOK, messages)
 	}
 }

--- a/app/history_v2_player_support.go
+++ b/app/history_v2_player_support.go
@@ -38,13 +38,6 @@ func HistoriesV2PSHandler(app *App) func(c echo.Context) error {
 		collection := app.Defaults.MongoMessagesCollection
 		messages = mongoclient.GetMessagesPlayerSupportV2WithParameter(c, topic, from, to, limit, collection, isBlocked, playerId)
 
-		gameId := messages[0].GameId
-		metricTagMap := c.Get("metricTagsMap").(map[string]interface{})
-		if metricTagMap != nil {
-			metricTagMap["gameID"] = gameId
-			logger.Logger.Debugf("provided gameID: %s", metricTagMap["gameID"])
-		}
-
 		return c.JSON(http.StatusOK, messages)
 	}
 }

--- a/app/middleware.go
+++ b/app/middleware.go
@@ -127,7 +127,6 @@ func (l LoggerMiddleware) Serve(next echo.HandlerFunc) echo.HandlerFunc {
 		}
 		//Everything went ok
 		reqLog.Info("Request successful.")
-
 		return result
 
 	}
@@ -192,7 +191,6 @@ func (nr *NewRelicMiddleware) Serve(next echo.HandlerFunc) echo.HandlerFunc {
 			txn.NoticeError(err)
 			return err
 		}
-
 		return nil
 	}
 }
@@ -228,9 +226,7 @@ func (responseTimeMiddleware ResponseTimeMetricsMiddleware) Serve(next echo.Hand
 			fmt.Sprintf("status:%d", status),
 			fmt.Sprintf("gameID:%v", gameID),
 		}
-
 		responseTimeMiddleware.DDStatsD.Timing(metricName, timeUsed, tags...)
-
 		return result
 	}
 }
@@ -302,7 +298,6 @@ func NewJaegerMiddleware() echo.MiddlewareFunc {
 			response := c.Response()
 			statusCode := response.Status()
 			span.SetTag("http.status_code", statusCode)
-
 			return err
 		}
 	}

--- a/app/middleware.go
+++ b/app/middleware.go
@@ -73,7 +73,6 @@ func (l LoggerMiddleware) Serve(next echo.HandlerFunc) echo.HandlerFunc {
 		var status int
 		var latency time.Duration
 		var startTime, endTime time.Time
-		// var caller interface{}
 
 		path = c.Path()
 		method = c.Request().Method()

--- a/app/middleware.go
+++ b/app/middleware.go
@@ -70,11 +70,10 @@ func (l LoggerMiddleware) Serve(next echo.HandlerFunc) echo.HandlerFunc {
 		)
 
 		// all except latency to string
-		var ip, method, path string
+		var ip, method, path, gameID string
 		var status int
 		var latency time.Duration
 		var startTime, endTime time.Time
-		var gameID interface{}
 
 		path = c.Path()
 		method = c.Request().Method()
@@ -87,7 +86,7 @@ func (l LoggerMiddleware) Serve(next echo.HandlerFunc) echo.HandlerFunc {
 		result := next(c)
 
 		if metricTagsMap, ok := c.Get("metricTagsMap").(map[string]interface{}); ok {
-			gameID = metricTagsMap["gameID"]
+			gameID, _ = metricTagsMap["gameID"].(string)
 		}
 
 		// no time.Since in order to format it well after
@@ -111,7 +110,7 @@ func (l LoggerMiddleware) Serve(next echo.HandlerFunc) echo.HandlerFunc {
 			zap.String("ip", ip),
 			zap.String("method", method),
 			zap.String("path", path),
-			zap.String("gameID", fmt.Sprintf("%v", gameID)),
+			zap.String("gameID", gameID),
 		)
 
 		//request failed
@@ -213,9 +212,9 @@ func (responseTimeMiddleware ResponseTimeMetricsMiddleware) Serve(next echo.Hand
 		route := c.Path()
 		method := c.Request().Method()
 
-		var gameID interface{}
+		var gameID string
 		if metricTagsMap, ok := c.Get("metricTagsMap").(map[string]interface{}); ok {
-			gameID = metricTagsMap["gameID"]
+			gameID, _ = metricTagsMap["gameID"].(string)
 		}
 
 		timeUsed := time.Since(startTime)

--- a/app/middleware.go
+++ b/app/middleware.go
@@ -73,9 +73,11 @@ func (l LoggerMiddleware) Serve(next echo.HandlerFunc) echo.HandlerFunc {
 		var status int
 		var latency time.Duration
 		var startTime, endTime time.Time
+		var caller string
 
 		path = c.Path()
 		method = c.Request().Method()
+		caller = c.Request().RealIP()
 
 		startTime = time.Now()
 
@@ -102,6 +104,7 @@ func (l LoggerMiddleware) Serve(next echo.HandlerFunc) echo.HandlerFunc {
 			zap.String("ip", ip),
 			zap.String("method", method),
 			zap.String("path", path),
+			zap.String("caller:%s", caller),
 		)
 
 		//request failed

--- a/app/middleware.go
+++ b/app/middleware.go
@@ -69,7 +69,7 @@ func (l LoggerMiddleware) Serve(next echo.HandlerFunc) echo.HandlerFunc {
 			zap.String("source", "request"),
 		)
 
-		//all except latency to string
+		// all except latency to string
 		var ip, method, path string
 		var status int
 		var latency time.Duration
@@ -90,7 +90,7 @@ func (l LoggerMiddleware) Serve(next echo.HandlerFunc) echo.HandlerFunc {
 			gameID = metricTagsMap["gameID"]
 		}
 
-		//no time.Since in order to format it well after
+		// no time.Since in order to format it well after
 		endTime = time.Now()
 		latency = endTime.Sub(startTime)
 
@@ -204,8 +204,8 @@ type ResponseTimeMetricsMiddleware struct {
 	DDStatsD *middleware.DogStatsD
 }
 
-//ResponseTimeMetricsMiddleware is a middleware to measure the response time
-//of a route and send it do StatsD
+// ResponseTimeMetricsMiddleware is a middleware to measure the response time
+// of a route and send it do StatsD
 func (responseTimeMiddleware ResponseTimeMetricsMiddleware) Serve(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 
@@ -235,7 +235,7 @@ func (responseTimeMiddleware ResponseTimeMetricsMiddleware) Serve(next echo.Hand
 	}
 }
 
-//ResponseTimeMetricsMiddleware returns a new ResponseTimeMetricsMiddleware
+// ResponseTimeMetricsMiddleware returns a new ResponseTimeMetricsMiddleware
 func NewResponseTimeMetricsMiddleware(ddStatsD *middleware.DogStatsD) *ResponseTimeMetricsMiddleware {
 	return &ResponseTimeMetricsMiddleware{
 		DDStatsD: ddStatsD,

--- a/app/middleware.go
+++ b/app/middleware.go
@@ -79,13 +79,17 @@ func (l LoggerMiddleware) Serve(next echo.HandlerFunc) echo.HandlerFunc {
 
 		startTime = time.Now()
 
-		metricTagMap := make(map[string]interface{})
-		c.Set("metricTagsMap", metricTagMap)
+		metricTagsMap := make(map[string]interface{})
+		c.Set("metricTagsMap", metricTagsMap)
 
 		result := next(c)
 
-		caller := c.Get("metricTagsMap")
-		caller = caller.(map[string]interface{})["gameID"]
+		if metricTagsMap, ok := c.Get("metricTagsMap").(map[string]interface{}); ok {
+			gameID = metricTagsMap["gameID"].(string)
+		}
+
+		// gameID := c.Get("metricTagsMap")
+		// gameID = gameID.(map[string]interface{})["gameID"]
 
 		//no time.Since in order to format it well after
 		endTime = time.Now()
@@ -108,7 +112,7 @@ func (l LoggerMiddleware) Serve(next echo.HandlerFunc) echo.HandlerFunc {
 			zap.String("ip", ip),
 			zap.String("method", method),
 			zap.String("path", path),
-			zap.String("caller", fmt.Sprintf("%v", caller)),
+			zap.String("gameID", gameID),
 		)
 
 		//request failed


### PR DESCRIPTION
# What?

To add tags informing which game is calling the MQTT History API to the metrics, allowing the team to narrow down the problem and to spot which game is having more trouble.

# How to test it

## Pre-requisites

1. Start the database and populate MongoDB with `make deps setup/mongo`;
2. Connect into mongoDB and run the following command:
```sh
> use chat

> db.messages.insertMany([
  {
    _id: ObjectId("61f18d6e901b304d707fd803"),
    id: 'urn:uuid:fe67bc4a-6517-4c96-a89d-09b7fe6e1e8e',
    player_id: '3727a9b4-dfa9-457a-9257-d2a7090d6955',
    game_id: 'mygame',
    topic: 'chat/mygame/room/general',
    message: 'Hello World',
    timestamp: 1643220334,
    blocked: false,
    metadata: {
      blocked: false,
      Type: 1,
      Time: NumberLong("637788171338607270"),
      Sender: { PlayerId: '3727a9b4-dfa9-457a-9257-d2a7090d6955', Name: 'Sonia Abrao' },
      Message: 'Hello World',
      Mentions: [],
      Id: 'urn:uuid:fe67bc4a-6517-4c96-a89d-09b7fe6e1e8e',
      GameId: 'mygame'
    },
    should_moderate: true,
    original_payload: {
      blocked: false,
      Type: 1,
      Time: NumberLong("637788171338607270"),
      Sender: { PlayerId: '3727a9b4-dfa9-457a-9257-d2a7090d6955', Name: 'Bob' },
      Message: 'Hello World',
      Mentions: [],
      Id: 'urn:uuid:fe67bc4a-6517-4c96-a89d-09b7fe6e1e8e',
      GameId: 'mygame'
    }
  }
])
```

3. Start the API with `make run`.

## Test case

### Retrieving messages from a player should log the provided caller

- **Given** I am an API consumer
- **When** I try to query my game messages
```sh
curl --location --request GET 'http://localhost:8888/v2/history/chat/mygame/room/general?userid=mygame:metagame-mygame&limit=10'
```
- **Then** I should return a JSON array with my messages and a request log informing the provided caller.
```sh
# you should see an array with one message from Sonia Abrao and a request log within  "caller":"mygame". 
```

--