### PR TITLE
feat: Create more granular OpenTracing spans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ create-cassandra-table:
 	@docker exec $(CASSANDRA_CONTAINER) cqlsh -e "$$(cat scripts/create.cql)";
 	@echo 'Done'
 
-# make setup/mongo MONGODB_HOST=mongodb://localhost:27017 or make MONGODB_HOST=mongodb://localhost:27017 setup/mongo
 setup/mongo: 
 	go run scripts/setup_mongo_messages-index.go
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Make sure you have Go installed on your machine.
 
 You also need to have access to running instances of Cassandra and Mongo.
 
-## Running the application
+### Running the application
 
 If you want to run the application locally you can do so by running
 
@@ -57,7 +57,7 @@ You may need to change the configurations to point to your MQTT, Cassandra
 and Mongo servers, or you can use the provided containers, they can be run
 by executing `make run-containers`
 
-## Running the tests
+### Running the tests
 
 The project is integrated with Github Actions and uses docker to run the needed services.
 
@@ -91,3 +91,22 @@ httpAuth:
       username: user
       password: pass
 ```
+## Observability
+
+### Logs
+
+There is a middleware using the [zap](https://github.com/uber-go/zap) package to log requests with the JSON zap encoder.
+
+All other pieces of code use the [op](https://github.com/op/go-logging) package with a custom format.
+
+⚠️ Only logs formatted as JSON are usually exported to a logging platform, i.e., only the aforementioned middleware is logging correctly and the team should fix this issue.
+
+### Traces
+
+OpenTracing is used to report traces. The client implementation used is Jaeger's.
+
+⚠️ OpenTracing is deprecated, as well as Jaeger's client package. That is, the team should replace OpenTracing with OpenTelemetry and Jaeger's client package with OpenTelemetry's agnostic client package.
+
+## Metrics
+
+Metrics are exported using [Datadog's statsd](https://github.com/DataDog/datadog-go) client package.

--- a/app/app.go
+++ b/app/app.go
@@ -163,7 +163,6 @@ func (app *App) configureJaeger() {
 			cfg.Sampler.Type = jaeger.SamplerTypeProbabilistic
 		}
 	}
-	logger.Logger.Info("Jaeger Config: ", cfg)
 	if _, err := cfg.InitGlobalTracer(""); err != nil {
 		logger.Logger.Error("Failed to initialize Jaeger.", err)
 	} else {
@@ -208,7 +207,6 @@ func (app *App) configureApplication() {
 	a.Use(NewLoggerMiddleware(zap.New(
 		zap.NewJSONEncoder(),
 	)).Serve)
-	a.Use(NewJaegerMiddleware())
 	a.Use(NewSentryMiddleware().Serve)
 	a.Use(VersionMiddleware)
 	a.Use(NewRecoveryMiddleware(app.OnErrorHandler).Serve)

--- a/app/helpers.go
+++ b/app/helpers.go
@@ -82,7 +82,11 @@ func findAuthorizedTopics(ctx context.Context, username string, topics []string)
 		return cursor.All(ctx, &searchResults)
 	}
 	search := func() error {
-		return mongoclient.GetCollection("mqtt_acl", query)
+		mongoCollection, err := mongoclient.GetCollection(ctx, "mqtt_acl")
+		if err != nil {
+			return err
+		}
+		return query(mongoCollection)
 	}
 	err := search()
 	return searchResults, err

--- a/app/histories.go
+++ b/app/histories.go
@@ -36,7 +36,15 @@ func HistoriesHandler(app *App) func(c echo.Context) error {
 			collection := app.Defaults.MongoMessagesCollection
 
 			for _, topic := range authorizedTopics {
-				topicMessages := mongoclient.GetMessages(c, topic, from, limit, collection)
+				topicMessages := mongoclient.GetMessages(
+					c,
+					mongoclient.QueryParameters{
+						Topic:      topic,
+						From:       from,
+						Limit:      limit,
+						Collection: collection,
+					},
+				)
 				messages = append(messages, topicMessages...)
 			}
 			return c.JSON(http.StatusOK, messages)

--- a/app/histories_test.go
+++ b/app/histories_test.go
@@ -176,7 +176,10 @@ func TestHistoriesHandler(t *testing.T) {
 					return err
 				}
 
-				err := mongoclient.GetCollection("mqtt_acl", query)
+				mongoCollection, err := mongoclient.GetCollection(ctx, "mqtt_acl")
+				Expect(err).To(BeNil())
+
+				err = query(mongoCollection)
 				Expect(err).To(BeNil())
 
 				testMessage := models.Message{

--- a/app/histories_v2.go
+++ b/app/histories_v2.go
@@ -36,7 +36,15 @@ func HistoriesV2Handler(app *App) func(c echo.Context) error {
 		collection := app.Defaults.MongoMessagesCollection
 
 		for _, topic := range authorizedTopics {
-			topicMessages := mongoclient.GetMessagesV2(c, topic, from, limit, collection)
+			topicMessages := mongoclient.GetMessagesV2(
+				c,
+				mongoclient.QueryParameters{
+					Topic:      topic,
+					From:       from,
+					Limit:      limit,
+					Collection: collection,
+				},
+			)
 			messages = append(messages, topicMessages...)
 		}
 

--- a/app/history.go
+++ b/app/history.go
@@ -30,7 +30,15 @@ func HistoryHandler(app *App) func(c echo.Context) error {
 
 		if app.Defaults.MongoEnabled {
 			collection := app.Defaults.MongoMessagesCollection
-			messages := mongoclient.GetMessages(c, topic, from, limit, collection)
+			messages := mongoclient.GetMessages(
+				c,
+				mongoclient.QueryParameters{
+					Topic:      topic,
+					From:       from,
+					Limit:      limit,
+					Collection: collection,
+				},
+			)
 			return c.JSON(http.StatusOK, messages)
 		}
 

--- a/app/history_v2.go
+++ b/app/history_v2.go
@@ -33,7 +33,16 @@ func HistoryV2Handler(app *App) func(c echo.Context) error {
 
 		messages := make([]*models.MessageV2, 0)
 		collection := app.Defaults.MongoMessagesCollection
-		messages = mongoclient.GetMessagesV2WithParameter(c, topic, from, limit, collection, isBlocked)
+		messages = mongoclient.GetMessagesV2WithParameter(
+			c,
+			mongoclient.QueryParameters{
+				Topic:      topic,
+				From:       from,
+				Limit:      limit,
+				Collection: collection,
+				IsBlocked:  isBlocked,
+			},
+		)
 
 		if len(messages) > 0 {
 			gameId := messages[0].GameId

--- a/app/history_v2_player_support.go
+++ b/app/history_v2_player_support.go
@@ -36,7 +36,18 @@ func HistoriesV2PSHandler(app *App) func(c echo.Context) error {
 
 		messages := make([]*models.MessageV2, 0)
 		collection := app.Defaults.MongoMessagesCollection
-		messages = mongoclient.GetMessagesPlayerSupportV2WithParameter(c, topic, from, to, limit, collection, isBlocked, playerId)
+		messages = mongoclient.GetMessagesPlayerSupportV2WithParameter(
+			c,
+			mongoclient.QueryParameters{
+				Topic:      topic,
+				From:       from,
+				To:         to,
+				Limit:      limit,
+				Collection: collection,
+				IsBlocked:  isBlocked,
+				PlayerID:   playerId,
+			},
+		)
 
 		return c.JSON(http.StatusOK, messages)
 	}

--- a/mongoclient/get_messages_v2.go
+++ b/mongoclient/get_messages_v2.go
@@ -1,0 +1,121 @@
+package mongoclient
+
+import (
+	"context"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+	"github.com/topfreegames/mqtt-history/logger"
+	"github.com/topfreegames/mqtt-history/models"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// GetMessagesV2 returns messages stored in MongoDB by topic
+// It returns the MessageV2 model that is stored in MongoDB
+func GetMessagesV2(ctx context.Context, queryParameters QueryParameters) []*models.MessageV2 {
+	return GetMessagesV2WithParameter(ctx, queryParameters)
+}
+
+func GetMessagesV2WithParameter(ctx context.Context, queryParameters QueryParameters) []*models.MessageV2 {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "get_messages_v2_with_parameter")
+	defer span.Finish()
+
+	mongoCollection, err := GetCollection(ctx, queryParameters.Collection)
+	if err != nil {
+		span.SetTag("error", true)
+		span.LogFields(
+			log.Event("error"),
+			log.Message("Error getting collection from MongoDB"),
+			log.Error(err),
+		)
+		logger.Logger.Warning("Error getting collection from MongoDB", err)
+		return []*models.MessageV2{}
+	}
+
+	rawResults, err := getMessagesFromCollection(ctx, queryParameters, mongoCollection)
+	if err != nil {
+		logger.Logger.Warning("Error getting messages from MongoDB", err)
+		return []*models.MessageV2{}
+	}
+
+	// convert the raw results to the MessageV2 model
+	searchResults := make([]*models.MessageV2, len(rawResults))
+	for i := 0; i < len(rawResults); i++ {
+		searchResults[i], err = convertRawMessageToModelMessage(rawResults[i])
+
+		if err != nil {
+			span.SetTag("error", true)
+			span.LogFields(
+				log.Event("error"),
+				log.Message("Error converting messages from MongoDB to the program domain format"),
+				log.Error(err),
+			)
+			logger.Logger.Warningf("Error converting messages from MongoDB: %s", err.Error())
+			return []*models.MessageV2{}
+		}
+	}
+
+	return searchResults
+}
+
+func getMessagesFromCollection(
+	ctx context.Context,
+	queryParameters QueryParameters,
+	mongoCollection *mongo.Collection,
+) ([]MongoMessage, error) {
+	query := bson.M{
+		"topic": queryParameters.Topic,
+		"timestamp": bson.M{
+			"$lte": queryParameters.From,
+		},
+		"blocked": queryParameters.IsBlocked,
+	}
+	sort := bson.D{
+		{"topic", 1},
+		{"timestamp", -1},
+	}
+
+	statement := extractStatementForTrace(query, sort, queryParameters.Limit)
+	span, ctx := opentracing.StartSpanFromContext(
+		ctx,
+		"get_messages_from_collection",
+		opentracing.Tags{
+			"span.kind":    "client",
+			"db.statement": statement,
+			"db.type":      "mongo",
+			"db.instance":  database,
+			"db.user":      user,
+		},
+	)
+	defer span.Finish()
+
+	opts := options.Find()
+	opts.SetSort(sort)
+	opts.SetLimit(queryParameters.Limit)
+
+	cursor, err := mongoCollection.Find(ctx, query, opts)
+	if err != nil {
+		span.SetTag("error", true)
+		span.LogFields(
+			log.Event("error"),
+			log.Message("Error finding messages in MongoDB"),
+			log.Error(err),
+		)
+		return nil, err
+	}
+
+	rawResults := make([]MongoMessage, 0)
+	if err = cursor.All(ctx, &rawResults); err != nil {
+		span.SetTag("error", true)
+		span.LogFields(
+			log.Event("error"),
+			log.Message("Error decoding messages of a cursor from MongoDB"),
+			log.Error(err),
+		)
+		return nil, err
+	}
+
+	return rawResults, nil
+}

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -81,8 +81,11 @@ func AuthorizeTestUserInTopics(ctx context.Context, topics []string) error {
 		return err
 	}
 
-	err := mongoclient.GetCollection("mqtt_acl", insertAuthCallback)
-	return err
+	mongoCollection, err := mongoclient.GetCollection(ctx, "mqtt_acl")
+	if err != nil {
+		return err
+	}
+	return insertAuthCallback(mongoCollection)
 }
 
 func InsertMongoMessages(ctx context.Context, topics []string) error {
@@ -117,6 +120,9 @@ func InsertMongoMessagesWithParameters(ctx context.Context, topics []string, blo
 	}
 
 	messagesCollection := "messages"
-	err := mongoclient.GetCollection(messagesCollection, insertMessagesCallback)
-	return err
+	mongoCollection, err := mongoclient.GetCollection(ctx, messagesCollection)
+	if err != nil {
+		return nil
+	}
+	return insertMessagesCallback(mongoCollection)
 }


### PR DESCRIPTION
MQTT History API is not currently reporting detailed traces from an API endpoint entrance until reaching its database.

This PR create more granular OpenTracing spans specifically for the endpoint "/histories".

What is new:
- Minor code refactor that splits code files that serve both "/histories" and "/v2/histories" endpoints in two different files. The goal is better code organization.
- Better documentation in README.md.
- Create more granular OpenTracing spans for the piece of code that serves the endpoint "/histories".
- Minor code improvements.
- Fix duplicate traces being reported due to the fact that two different middlewares were doing the same thing: report traces.

Screenshot showing the more granular spans in the developer's local environment:
![Screen Shot 2022-09-29 at 14 42 22](https://user-images.githubusercontent.com/11428796/193107298-b34b7ee9-09cf-4f61-83b9-1d8be61ef1a4.png)
