### PR TITLE
perf: Queries issued by the /histories endpoint run concurrently

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -26,7 +26,6 @@ import (
 	"github.com/topfreegames/mqtt-history/models"
 	"github.com/uber-go/zap"
 
-	"github.com/uber/jaeger-client-go"
 	"github.com/uber/jaeger-client-go/config"
 )
 
@@ -158,9 +157,6 @@ func (app *App) configureJaeger() {
 	if !cfg.Disabled {
 		if cfg.ServiceName == "" {
 			cfg.ServiceName = "mqtt-history"
-		}
-		if cfg.Sampler.Type == "" {
-			cfg.Sampler.Type = jaeger.SamplerTypeProbabilistic
 		}
 	}
 	if _, err := cfg.InitGlobalTracer(""); err != nil {

--- a/app/histories.go
+++ b/app/histories.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/topfreegames/mqtt-history/mongoclient"
 
@@ -30,23 +31,51 @@ func HistoriesHandler(app *App) func(c echo.Context) error {
 			return c.String(echo.ErrUnauthorized.Code, echo.ErrUnauthorized.Message)
 		}
 
-		// retrieve messages
 		messages := make([]*models.Message, 0)
 		if app.Defaults.MongoEnabled {
 			collection := app.Defaults.MongoMessagesCollection
-
+			var wg sync.WaitGroup
+			var mu sync.Mutex
+			// guarantees ordering in responses payload
+			topicsMessagesMap := make(map[string][]*models.MessageV2, len(authorizedTopics))
 			for _, topic := range authorizedTopics {
-				topicMessages := mongoclient.GetMessages(
-					c,
-					mongoclient.QueryParameters{
-						Topic:      topic,
-						From:       from,
-						Limit:      limit,
-						Collection: collection,
-					},
-				)
-				messages = append(messages, topicMessages...)
+				wg.Add(1)
+				go func(topicsMessagesMap map[string][]*models.MessageV2, topic string) {
+					topicMessages := mongoclient.GetMessagesV2(
+						c,
+						mongoclient.QueryParameters{
+							Topic:      topic,
+							From:       from,
+							Limit:      limit,
+							Collection: collection,
+						},
+					)
+					mu.Lock()
+					topicsMessagesMap[topic] = topicMessages
+					mu.Unlock()
+					wg.Done()
+				}(topicsMessagesMap, topic)
 			}
+			wg.Wait()
+			var gameID string
+			// guarantees ordering in responses payload
+			for _, topic := range authorizedTopics {
+				topicMessages := make([]*models.Message, len(topicsMessagesMap[topic]))
+				for idx, topicMessageV2 := range topicsMessagesMap[topic] {
+					topicMessages[idx] = mongoclient.ConvertMessageV2ToMessage(topicMessageV2)
+				}
+				messages = append(messages, topicMessages...)
+				if gameID != "" && len(topicsMessagesMap[topic]) > 0 {
+					gameID = topicsMessagesMap[topic][0].GameId
+				}
+			}
+
+			if gameID != "" {
+				if metricTagsMap, ok := c.Get("metricTagsMap").(map[string]interface{}); ok {
+					metricTagsMap["gameID"] = gameID
+				}
+			}
+
 			return c.JSON(http.StatusOK, messages)
 		}
 

--- a/mongoclient/get_messages_v2.go
+++ b/mongoclient/get_messages_v2.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/topfreegames/mqtt-history/logger"
 	"github.com/topfreegames/mqtt-history/models"
@@ -82,11 +83,10 @@ func getMessagesFromCollection(
 		ctx,
 		"get_messages_from_collection",
 		opentracing.Tags{
-			"span.kind":    "client",
-			"db.statement": statement,
-			"db.type":      "mongo",
-			"db.instance":  database,
-			"db.user":      user,
+			string(ext.DBStatement): statement,
+			string(ext.DBType):      "mongo",
+			string(ext.DBInstance):  database,
+			string(ext.DBUser):      user,
 		},
 	)
 	defer span.Finish()


### PR DESCRIPTION
Problem: when messages from multiple topics are requested to the "/histories" endpoint, a query related to each topic is issued against the database in sequence; depending on which _limit_ of messages is requested, responses could take too long.

Partial solution: make queries be issued concurrently in the "/histories" endpoint.

There are 2 snapshots below showing the time spend by the API when issuing queries in sequence and concurrently, respectively. The improvement in time is visible even when running the stack using _docker compose_ on the developer's machine and using data from an already existing staging environment. Despite the lack of network latency, the images show some improvement. In production, the improvement will be greater for sure.

<img width="1672" alt="Screen Shot 2022-10-06 at 13 55 14" src="https://user-images.githubusercontent.com/11428796/194387446-345e9415-c223-469b-a1be-7d73d1d9084f.png">
<img width="1672" alt="Screen Shot 2022-10-06 at 13 55 28" src="https://user-images.githubusercontent.com/11428796/194387452-633d9ec8-0b75-4043-aa6d-c860b676837c.png">


